### PR TITLE
Data update script for bbref war data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,8 @@ jobs:
           command: pip install --user -r requirements-dev.txt
       - python/save-cache
       - run:
-          command: python -m pybaseballdatana.data.tools.update --update-source lahman --make-dirs
+          command: python -m pybaseballdatana.data.tools.update --data-source Lahman --make-dirs
+          command: python -m pybaseballdatana.data.tools.update --data-source BaseballReference --make-dirs
       - run:
           command: python -m pytest tests/
           name: Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,10 @@ jobs:
       - python/save-cache
       - run:
           command: python -m pybaseballdatana.data.tools.update --data-source Lahman --make-dirs
+          name: Update Lahman
+      - run:
           command: python -m pybaseballdatana.data.tools.update --data-source BaseballReference --make-dirs
+          name: Update Baseball Reference
       - run:
           command: python -m pytest tests/
           name: Test

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -24,7 +24,8 @@ jobs:
         pip install -e .
     - name: Initialize package data
       run: |
-        python -m pybaseballdatana.data.tools.update --update-source lahman --make-dirs
+        python -m pybaseballdatana.data.tools.update --data-source Lahman --make-dirs
+        python -m pybaseballdatana.data.tools.update --data-source BaseballReference --make-dirs
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/pybaseballdatana/data/tools/baseball_reference/_update.py
+++ b/pybaseballdatana/data/tools/baseball_reference/_update.py
@@ -17,24 +17,24 @@ def _download_csv(url):
     return list(it)
 
 
-def _save(lines, file_name):
-    output_path = (
-        pathlib.Path(__file__).absolute().parent.parent.parent
+def _save(lines, file_name, output_path=None):
+    output_path = (output_path or
+        pathlib.Path(__file__).absolute().parent.parent
         / "assets"
         / "BaseballReference"
-        / file_name
     )
+    output_file_path = os.path.join(output_path, file_name)
     output_payload = "\n".join(str(line, "utf-8") for line in lines)
-    logging.info("saving file to {}".format(output_path))
-    with gzip.open(output_path, "wb") as fh:
+    logging.info("saving file to {}".format(output_file_path))
+    with gzip.open(output_file_path, "wb") as fh:
         fh.write(bytes(output_payload, encoding="utf-8"))
 
 
-def _update_file(url):
+def _update_file(url, output_path=None):
     lines = _download_csv(url)
-    _save(lines, os.path.basename(url) + ".gz")
+    _save(lines, os.path.basename(url) + ".gz", output_path)
 
 
-def _update():
+def _update(output_path=None):
     for url in [WAR_BATTING_URL, WAR_PITCHING_URL]:
-        _update_file(url)
+        _update_file(url, output_path)

--- a/pybaseballdatana/data/tools/baseball_reference/data.py
+++ b/pybaseballdatana/data/tools/baseball_reference/data.py
@@ -3,12 +3,10 @@ import pathlib
 import os
 from ._update import _update_file
 from . import WAR_PITCHING_URL, WAR_BATTING_URL
+from pybaseballdatana import PYBBDA_DATA_ROOT
 
-DATA_PATH = (
-    pathlib.Path(__file__).absolute().parent.parent.parent
-    / "assets"
-    / "BaseballReference"
-)
+BBREF_DATA_PATH = PYBBDA_DATA_ROOT / "BaseballReference"
+
 BASEBALL_REFERENCE_TABLES = {
     "war_bat": "war_daily_bat.txt",
     "war_pitch": "war_daily_pitch.txt",
@@ -17,7 +15,7 @@ BASEBALL_REFERENCE_URLS = {"war_bat": WAR_BATTING_URL, "war_pitch": WAR_PITCHING
 
 
 class BaseballReferenceData:
-    def __init__(self, data_path=DATA_PATH, update=False):
+    def __init__(self, data_path=BBREF_DATA_PATH, update=False):
         self.tables = BASEBALL_REFERENCE_TABLES
         self.update = update
         self.data_path = data_path

--- a/pybaseballdatana/data/tools/lahman/_update.py
+++ b/pybaseballdatana/data/tools/lahman/_update.py
@@ -20,7 +20,7 @@ def _download():
 
 
 def _extract(target, output_path=None):
-    output_path = output_path or pathlib.Path(__file__).parent / "Lahman"
+    output_path = output_path or pathlib.Path(__file__).parent.parent / "assets" / "Lahman"
 
     if not os.path.isdir(output_path):
         raise ValueError(f"Path {output_path} must be a directory")

--- a/pybaseballdatana/data/tools/update.py
+++ b/pybaseballdatana/data/tools/update.py
@@ -6,7 +6,7 @@ from pybaseballdatana import PYBBDA_DATA_ROOT
 
 
 from .lahman._update import _update as update_lahman
-
+from .baseball_reference._update import _update as update_bbref
 
 def _parse_args():
     parser = argparse.ArgumentParser()
@@ -17,9 +17,9 @@ def _parse_args():
         help="Root directory for data storage",
     )
     parser.add_argument(
-        "--update-source",
+        "--data-source",
         required=True,
-        choices=("lahman", "baseball-reference"),
+        choices=("Lahman", "BaseballReference"),
         help="Update source",
     )
     parser.add_argument(
@@ -30,13 +30,21 @@ def _parse_args():
     )
     return parser.parse_args(sys.argv[1:])
 
+def update_source(data_root, data_source):
+    if data_source == "Lahman":
+        update_lahman(os.path.join(data_root, data_source))
+    elif data_source == "BaseballReference":
+        update_bbref(os.path.join(data_root, data_source))
+
+
+def create_dir_if_not_exist(data_root, data_source):
+    os.makedirs(os.path.join(data_root, data_source), exist_ok=True)
 
 def main():
     args = _parse_args()
     if args.make_dirs:
-        os.makedirs(os.path.join(args.data_root, "Lahman"), exist_ok=True)
-    update_lahman(os.path.join(args.data_root, "Lahman"))
-
+        create_dir_if_not_exist(args.data_root, args.data_source)
+    update_source(args.data_root, args.data_source)
 
 if __name__ == "__main__":
     main()

--- a/tests/test_baseball_reference/test_baseball_reference_data.py
+++ b/tests/test_baseball_reference/test_baseball_reference_data.py
@@ -4,7 +4,7 @@ from pybaseballdatana.data import BaseballReferenceData
 
 @pytest.fixture
 def baseball_ref_data():
-    return BaseballReferenceData(update=True)
+    return BaseballReferenceData(update=False)
 
 def test_war_bat(baseball_ref_data):
     war_bat = baseball_ref_data.war_bat


### PR DESCRIPTION
Updates the update script with an option to download baseball-reference data. User is now expected to explicitly initialize the data, e.g.,

```
python -m pybaseballdatana.data.tools.update --data-source BaseballReference --make-dirs
```

This PR also changes the syntax for the update script in general, so the command  to download Lahman data is now,

```
python -m pybaseballdatana.data.tools.update --data-source Lahman --make-dirs
```

