### PR TITLE
Updates requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,4 +61,3 @@ install-dev:
 
 install: install-dev
 	pip install .
-	

--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,13 @@ lint: install-dev
 	python -m flake8 examples
 
 
-test-analysis: install-dev install-data
+test-analysis: install-dev
 	python -m pytest tests/analysis/
 
-test-data: install-dev install-data
+test-data: install-dev
 	python -m pytest tests/data/
 
-test-markov: install install-data
+test-markov: install
 	python -m pybbda.analysis.run_expectancy.markov.cli \
 	-b 0 0.1 0.1 0.1 0.1 0.1 \
 	-i 1 henderi01_1982
@@ -26,7 +26,7 @@ test-markov: install install-data
 	-i 1 henderi01_1982 \
 	-i 4 ruthba01_1927
 
-test: install-dev install-data
+test: install-dev
 	python -m pytest tests/
 
 clean-docs:
@@ -61,3 +61,4 @@ install-dev:
 
 install: install-dev
 	pip install .
+	

--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,13 @@ lint: install-dev
 	python -m flake8 examples
 
 
-test-analysis: install-dev
+test-analysis: install-dev install-data
 	python -m pytest tests/analysis/
 
-test-data: install-dev
+test-data: install-dev install-data
 	python -m pytest tests/data/
 
-test-markov: install
+test-markov: install install-data
 	python -m pybbda.analysis.run_expectancy.markov.cli \
 	-b 0 0.1 0.1 0.1 0.1 0.1 \
 	-i 1 henderi01_1982
@@ -26,7 +26,7 @@ test-markov: install
 	-i 1 henderi01_1982 \
 	-i 4 ruthba01_1927
 
-test: install-dev
+test: install-dev install-data
 	python -m pytest tests/
 
 clean-docs:
@@ -60,4 +60,4 @@ install-dev:
 	pip install --quiet -r requirements-dev.txt
 
 install: install-dev
-	pip install -e .
+	pip install .

--- a/pybbda/data/sources/fangraphs/_update.py
+++ b/pybbda/data/sources/fangraphs/_update.py
@@ -101,8 +101,10 @@ def _pool_park_factors_update(overwrite=False, season_root=None):
             overwrite=overwrite,
         )
     else:
-        logger.info(f"handedness park factors not available for pre-2002 seasons. "
-                    f"skipping {season}")
+        logger.info(
+            f"handedness park factors not available for pre-2002 seasons. "
+            f"skipping {season}"
+        )
 
 
 def _pool_do_update(overwrite=False, season_stats=None):

--- a/pybbda/data/sources/retrosheet/data.py
+++ b/pybbda/data/sources/retrosheet/data.py
@@ -1,5 +1,4 @@
 import os
-import psycopg2
 import pandas as pd
 import logging
 import glob
@@ -35,15 +34,6 @@ class RetrosheetData(DataSource):
         self.db_path = os.path.join(self.db_dir, "retrosheet.db")
         self._engine = None
         self.chadwick = Chadwick()
-
-    def _connect_to_postgres(self, database="retrosheet"):
-        conn = psycopg2.connect(
-            database=database,
-            user=os.environ["PSQL_USER"],
-            password=os.environ["PSQL_PASS"],
-            port=os.environ["PSQL_PORT"],
-        )
-        return conn
 
     def create_database(self):
         if not os.path.exists(self.db_dir):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ lxml~=4.5.0
 numpy~=1.18.1
 pandas~=1.0.4
 requests~=2.22.0
-psycopg2~=2.8.4
 scipy~=1.4.1
 sqlalchemy~=1.3.13
 tqdm~=4.46.1

--- a/tests/data/test_baseball_reference/test_baseball_reference_data.py
+++ b/tests/data/test_baseball_reference/test_baseball_reference_data.py
@@ -10,13 +10,13 @@ def baseball_ref_data():
 def test_war_bat(baseball_ref_data):
     war_bat = baseball_ref_data.war_bat
     assert war_bat.year_ID.min() == 1871
-    assert war_bat.year_ID.max() == 2019
+    assert war_bat.year_ID.max() == 2020
 
 
 def test_war_pitch(baseball_ref_data):
     war_pitch = baseball_ref_data.war_pitch
     assert war_pitch.year_ID.min() == 1871
-    assert war_pitch.year_ID.max() == 2019
+    assert war_pitch.year_ID.max() == 2020
 
 
 def test_missing_path(baseball_ref_data):

--- a/tests/data/test_statcast/test_statcast.py
+++ b/tests/data/test_statcast/test_statcast.py
@@ -34,5 +34,9 @@ def test_statcast_validate_player_type(statcast_data):
 
 def test_statcast_batter_data(statcast_data):
     df = statcast_data.sc_2019_05_01
-    mean_ls = df.query('player_name == "Jose Abreu"').loc[:, "launch_speed"].mean()
-    assert mean_ls == pytest.approx(90.8, 0.01)
+    mean_ls = (
+        df.query('player_name == "Jose Abreu" and description != "foul"')
+        .loc[:, "launch_speed"]
+        .mean()
+    )
+    assert mean_ls == pytest.approx(102.05, 0.01)


### PR DESCRIPTION
Removes the `psycopg2` dependency. It's not being used and can cause install errors if the user doesn't have postgres and python dev libraries installed on their system. Partially addresses https://github.com/bdilday/pybbda/issues/49