### PR TITLE
bumps pychadwick version

### DIFF
--- a/pybbda/__init__.py
+++ b/pybbda/__init__.py
@@ -5,7 +5,7 @@ import logging
 logging.basicConfig(format="%(levelname)s:%(name)s:%(module)s:%(message)s")
 logger = logging.getLogger("pybbda")
 
-_version = "0.3.0"
+_version = "0.3.1"
 
 PYBBDA_LOG_LEVEL_NAME = os.environ.get("PYBBDA_LOG_LEVEL", "")
 _PYBBDA_LOG_LEVEL_MAP = {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest==5.3.4
+pytest>=6.0.0
 tox==3.14.3
 setuptools
 Sphinx==3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ requests~=2.22.0
 scipy~=1.4.1
 sqlalchemy~=1.3.13
 tqdm~=4.46.1
-pychadwick~=0.4.0
+pychadwick~=0.5.0
 matplotlib~=3.1.3
 seaborn~=0.10.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.3.1
 
 [flake8]
 max-line-length = 90

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("requirements.txt", "r") as fh:
 
 setup(
     name="pybbda",
-    version="0.3.0",
+    version="0.3.1",
     author="Ben Dilday",
     author_email="ben.dilday.phd@gmail.com",
     description="Baseball data and analysis in Python",

--- a/tests/analysis/simulations/components/test_player_registry.py
+++ b/tests/analysis/simulations/components/test_player_registry.py
@@ -38,4 +38,4 @@ def test_from_lahman_records():
 def test_from_lahman():
     player_registry = PlayerRegistry()
     player_registry.load_from_lahman(pa_limit=180)
-    assert player_registry.len == 32646
+    assert player_registry.len == 32803

--- a/tests/data/test_lahman/test_lahman.py
+++ b/tests/data/test_lahman/test_lahman.py
@@ -8,7 +8,7 @@ def lahman_data():
 
 
 def test_lahman_datadum(lahman_data):
-    assert len(lahman_data.batting) == 107429
+    assert len(lahman_data.batting) == 108789
 
 
 def test_missing_path(lahman_data):


### PR DESCRIPTION
bumps pychadwick version to `0.5.x`, which is the first minor version of `pychadwick` that can be installed on non-linux systems.