### PR TITLE
lahman-data export 

### DIFF
--- a/pybbda/data/sources/lahman/_update.py
+++ b/pybbda/data/sources/lahman/_update.py
@@ -24,7 +24,7 @@ def _download():
 def _extract(target, output_root):
     output_path = os.path.join(output_root, "Lahman")
     os.makedirs(output_path, exist_ok=True)
-    extracted_files = glob.glob(os.path.join(target, "**", "*csv"), recursive=True)
+    extracted_files = glob.glob(os.path.join(target, "baseballdatabank-master", "core", "*csv"), recursive=True)
     for extracted_file in extracted_files:
         try:
             shutil.copy(extracted_file, output_path)

--- a/pybbda/data/sources/lahman/data.py
+++ b/pybbda/data/sources/lahman/data.py
@@ -1,6 +1,7 @@
 import re
 import os
 import logging
+from pathlib import Path
 
 import pandas as pd
 
@@ -21,7 +22,7 @@ class LahmanData(Singleton):
         """
         if data_path is None:
             data_path = LAHMAN_DATA_PATH
-        self.data_path = data_path
+        self.data_path = Path(data_path)
         for file_name in _LAHMAN_TABLES:
             self.__setattr__(self._munge_attr_name(file_name), None)
 

--- a/tests/data/test_baseball_reference/test_baseball_reference_data.py
+++ b/tests/data/test_baseball_reference/test_baseball_reference_data.py
@@ -10,13 +10,13 @@ def baseball_ref_data():
 def test_war_bat(baseball_ref_data):
     war_bat = baseball_ref_data.war_bat
     assert war_bat.year_ID.min() == 1871
-    assert war_bat.year_ID.max() == 2020
+    assert war_bat.year_ID.max() >= 2021
 
 
 def test_war_pitch(baseball_ref_data):
     war_pitch = baseball_ref_data.war_pitch
     assert war_pitch.year_ID.min() == 1871
-    assert war_pitch.year_ID.max() == 2020
+    assert war_pitch.year_ID.max() >= 2021
 
 
 def test_missing_path(baseball_ref_data):

--- a/tests/data/test_statcast/test_statcast.py
+++ b/tests/data/test_statcast/test_statcast.py
@@ -35,7 +35,7 @@ def test_statcast_validate_player_type(statcast_data):
 def test_statcast_batter_data(statcast_data):
     df = statcast_data.sc_2019_05_01
     mean_ls = (
-        df.query('player_name == "Jose Abreu" and description != "foul"')
+        df.query('batter == 547989 and description != "foul"')
         .loc[:, "launch_speed"]
         .mean()
     )


### PR DESCRIPTION
The github version of [baseball-databank](https://github.com/chadwickbureau/baseballdatabank), has a directory `upstream`, containg a file `Teams.csv`. Previously `pybbda` downloaded the zip-file archive and unpacked it with a wildcard `**/*csv`, which caused this `Teams.csv` to overwrite the `core/Teams.csv` file. This PR change sthe glob pattern to avoid this.